### PR TITLE
/product/postにて、INSERTクエリが同数用意される問題を解決しました。

### DIFF
--- a/webapp/backend/internal/repository/order.go
+++ b/webapp/backend/internal/repository/order.go
@@ -19,18 +19,60 @@ func NewOrderRepository(db DBTX) *OrderRepository {
 	return &OrderRepository{db: db}
 }
 
-// 注文を作成し、生成された注文IDを返す
+// 複数の注文を一括作成し、生成された注文IDのスライスを返す
+func (r *OrderRepository) CreateBatch(ctx context.Context, orders []*model.Order) ([]string, error) {
+	if len(orders) == 0 {
+		return []string{}, nil
+	}
+
+	// バッチINSERT用のクエリを構築
+	query := `INSERT INTO orders (user_id, product_id, shipped_status, created_at) VALUES `
+	placeholders := make([]string, len(orders))
+	args := make([]interface{}, 0, len(orders)*4)
+
+	for i, order := range orders {
+		placeholders[i] = "(?, ?, 'shipping', NOW())"
+		args = append(args, order.UserID, order.ProductID)
+	}
+
+	query += strings.Join(placeholders, ", ")
+
+	result, err := r.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	// 最初のIDを取得
+	firstID, err := result.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+
+	// 連続するIDのスライスを生成
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return nil, err
+	}
+
+	orderIDs := make([]string, rowsAffected)
+	for i := int64(0); i < rowsAffected; i++ {
+		orderIDs[i] = fmt.Sprintf("%d", firstID+i)
+	}
+
+	return orderIDs, nil
+}
+
+// 注文を作成し、生成された注文IDを返す（単一注文用）
 func (r *OrderRepository) Create(ctx context.Context, order *model.Order) (string, error) {
-	query := `INSERT INTO orders (user_id, product_id, shipped_status, created_at) VALUES (?, ?, 'shipping', NOW())`
-	result, err := r.db.ExecContext(ctx, query, order.UserID, order.ProductID)
+	// 単一注文をバッチメソッドで処理
+	orderIDs, err := r.CreateBatch(ctx, []*model.Order{order})
 	if err != nil {
 		return "", err
 	}
-	id, err := result.LastInsertId()
-	if err != nil {
-		return "", err
+	if len(orderIDs) == 0 {
+		return "", fmt.Errorf("no order ID generated")
 	}
-	return fmt.Sprintf("%d", id), nil
+	return orderIDs[0], nil
 }
 
 // 複数の注文IDのステータスを一括で更新

--- a/webapp/backend/internal/service/product.go
+++ b/webapp/backend/internal/service/product.go
@@ -30,19 +30,25 @@ func (s *ProductService) CreateOrders(ctx context.Context, userID int, items []m
 			return nil
 		}
 
+		// 全ての注文をスライスに格納
+		var orders []*model.Order
 		for pID, quantity := range itemsToProcess {
 			for i := 0; i < quantity; i++ {
 				order := &model.Order{
 					UserID:    userID,
 					ProductID: pID,
 				}
-				orderID, err := txStore.OrderRepo.Create(ctx, order)
-				if err != nil {
-					return err
-				}
-				insertedOrderIDs = append(insertedOrderIDs, orderID)
+				orders = append(orders, order)
 			}
 		}
+
+		// バッチINSERTで一括作成
+		orderIDs, err := txStore.OrderRepo.CreateBatch(ctx, orders)
+		if err != nil {
+			return err
+		}
+		insertedOrderIDs = orderIDs
+		
 		return nil
 	})
 


### PR DESCRIPTION
``/product/post``APIにて品を登録する際にその個数分のINSERTが発行されるのを、一つにまとめるようにしました。